### PR TITLE
DialogBusy replaced with DialogBusyNoCancel

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -667,7 +667,7 @@ class MenuNavigator():
             level = forceLevel
 
         # This could take a little time to set the value so show the busy dialog
-        xbmc.executebuiltin("ActivateWindow(busydialog)")
+        xbmc.executebuiltin("ActivateWindow(busydialognocancel)")
 
         if title not in [None, ""]:
             pinDB = PinSentryDB()
@@ -702,7 +702,7 @@ class MenuNavigator():
             # Handle the bulk operations like set All security for the movies
             self._setBulkSecurity(type, level)
 
-        xbmc.executebuiltin("Dialog.Close(busydialog)")
+        xbmc.executebuiltin("Dialog.Close(busydialognocancel)")
         xbmc.executebuiltin("Container.Refresh")
 
     # Sets the security details on all the Movies in a given Movie Set


### PR DESCRIPTION
https://forum.kodi.tv/showthread.php?tid=303073&pid=2739256#pid2739256

Usage of DialogBusy results in nop now. I removed it becuase it was wrong: 13954 (PR)

Unfortunately Kodi's GUI lacks a proper MVC (model view controller) architecture. Giving addons the chance to open modal dialogs in an uncontrolled manner is wrong. In this particular case it lead to crashes that I fixed with this change. DialogBusy is a singelto and must only be used once at a given time.

EDIT: as a workaround python scripts can make use of the new DialogBusyNoCancel: 13958 (PR)